### PR TITLE
removing extra nav bar div

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -72,45 +72,6 @@
     </nav>
   </div>
 
-  <!-- Navbar for small sized (mobile and tab) screens --> 
-  <!-- Bootstrap 4 nav bar is not yet completely optimised, I am cheating abit here by having separate nav bars for small screens and screens which are medium and above. Bootstrap 4 will eventually fix this or else I will implement a custom nav bar to fit all screens --> 
-  <div class="hidden-sm-up">
-    <nav class="navbar navbar-toggleable-md bg-custom navbar-light bg-faded">
-      <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#miniNavbarSupportedContent" aria-controls="miniNavbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-        <i class="fa fa-bars fa-1x">
-        </i>
-      </button>
-      <a class="navbar-brand" href="/index.html">
-        <img src="img/logo-mono.png" height="50">
-      </a>
-
-      <div class="collapse navbar-collapse" id="miniNavbarSupportedContent">
-        <ul class="navbar-nav">
-          <li class="nav-item">
-            <a class="nav-link scroll" target="learn">
-              <i class="fa fa-graduation-cap"></i>&nbspLEARN
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link scroll" target="download">
-              <i class="fa fa-download"></i>&nbsp;DOWNLOAD
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link scroll" target="community">
-              <i class="fa fa-users"></i>&nbsp;COMMUNITY
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link scroll" target="license">
-              <i class="fa fa-legal"></i>&nbsp;LICENSE
-            </a>
-          </li>
-        </ul>
-      </div>
-    </nav>
-  </div>
-
   <!-- Landing section -->
   <div class="page-header clear-filter vc">
     <div class="container text-center content">


### PR DESCRIPTION
issue xref: [https://github.com/cdk/cdk.github.io/issues/12](url)

Uncertain if this can be updated, but after testing locally in Chrome (and Safari) using the inspect tool it seems the extra nav bar div is now obsolete.