### PR TITLE
Typo on landing page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -197,7 +197,7 @@
               <div class="card-body">
                 <p class="card-text">
                   <i class="fa fa-book" aria-hidden="true"></i>&nbsp;
-                  <a href="https://egonw.github.io/cdkbook/">Groovy Cheminformatics with the CDK&nbsp;-&nbsp;Book</a>)
+                  <a href="https://egonw.github.io/cdkbook/">Groovy Cheminformatics with the CDK&nbsp;-&nbsp;Book</a>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
There was a small typo that allowed a ")" to show on the site.