### PR TITLE
Update index.html

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -365,7 +365,7 @@
                 </li>
               </ul>
               <br>
-              If you wish to cite the use of CDK please reference the above journal articles. Use of a specific version (since 1.5.7) can also be cited by DOI provided by <a class="text-danger" target="_blank" href="https://zenodo.org/search?page=1&size=20&q=CDK%20Release">Zenodo</a>.
+              If you wish to cite the use of CDK please reference the above journal articles. Use of a specific version (since 1.5.7) can also be cited by DOI provided by <a class="text-danger" target="_blank" href="https://doi.org/10.5281/zenodo.592588">Zenodo</a>.
             </p>
 
           </div>


### PR DESCRIPTION
The Zenodo link redirects to many different CDK-related entries, I updated it to the "master" DOI for the CDK release (https://doi.org/10.5281/zenodo.592588).

![image](https://user-images.githubusercontent.com/4070141/161918723-10010aec-ed14-41dd-85e9-2d19c4fc19ba.png)
