### PR TITLE
npm audit fix, updates Babel dependencies to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "browser-sync": "^2.29.3",
         "browser-sync-webpack-plugin": "^2.3.0",
         "copy-webpack-plugin": "^12.0.2",
+        "cross-env": "^7.0.3",
         "css-loader": "^7.1.2",
         "html-webpack-plugin": "^5.6.3",
         "mini-css-extract-plugin": "^2.9.2",
@@ -2940,6 +2941,24 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -5,19 +5,20 @@
   "main": "bundle.js",
   "scripts": {
     "dev": "webpack",
-    "production": "NODE_ENV=production webpack",
+    "production": "cross-env NODE_ENV=production webpack",
     "watch": "npm run dev -- --watch"
   },
   "keywords": [],
   "author": "cs76",
   "license": "",
   "devDependencies": {
-    "@babel/preset-env": "^7.26.7",
     "@babel/core": "^7.26.7",
+    "@babel/preset-env": "^7.26.7",
     "babel-loader": "^9.2.1",
     "browser-sync": "^2.29.3",
     "browser-sync-webpack-plugin": "^2.3.0",
     "copy-webpack-plugin": "^12.0.2",
+    "cross-env": "^7.0.3",
     "css-loader": "^7.1.2",
     "html-webpack-plugin": "^5.6.3",
     "mini-css-extract-plugin": "^2.9.2",


### PR DESCRIPTION
Also added cross-env dependency so that `npm run production` work platform independent.